### PR TITLE
Fix comment typo in utils

### DIFF
--- a/utils/string.go
+++ b/utils/string.go
@@ -1,6 +1,6 @@
 package utils
 
-// CountChars counts the number of occurences of a character in a string.
+// CountChars counts the number of occurrences of a character in a string.
 func CountChars(Str string, Ch rune) (n int) {
 	for _, ch := range Str {
 		if ch == Ch {


### PR DESCRIPTION
## Summary
- correct a spelling error in `CountChars` comment

## Testing
- `go vet ./...` *(fails: generic type alias requires GOEXPERIMENT)*

------
https://chatgpt.com/codex/tasks/task_e_6842f9e4c5908331bea8a5f598d10a59